### PR TITLE
Fixed error with url-join import

### DIFF
--- a/src/NpmRegistryClient.ts
+++ b/src/NpmRegistryClient.ts
@@ -1,4 +1,4 @@
-import * as urlJoin from "url-join";
+import urlJoin = require("url-join");
 import * as path from "path";
 import * as fs from "./fileSystem";
 import { downloadTarball, extractTarball } from "./tarballUtils";


### PR DESCRIPTION
The error Module 'url-join' resolves to a non-module entity and cannot be imported using this construct is caused due to the import statement import * as urlJoin from 'url-join'. The supported syntax is import urlJoin = require('url-join')