### PR TITLE
Fixed compile errors with @types/jest and url-join import

### DIFF
--- a/src/NpmRegistryClient.ts
+++ b/src/NpmRegistryClient.ts
@@ -1,4 +1,4 @@
-import * as urlJoin from "url-join";
+import urlJoin from "url-join";
 import * as path from "path";
 import * as fs from "./fileSystem";
 import { downloadTarball, extractTarball } from "./tarballUtils";

--- a/src/PluginVm.ts
+++ b/src/PluginVm.ts
@@ -186,6 +186,7 @@ export class PluginVm {
 			}
 		);
 
+		//@ts-ignore
 		const moduleRequire: NodeRequire = Object.assign(
 			(requiredName: string) => {
 				if (debug.enabled) {

--- a/src/PluginVm.ts
+++ b/src/PluginVm.ts
@@ -186,7 +186,6 @@ export class PluginVm {
 			}
 		);
 
-		//@ts-ignore
 		const moduleRequire: NodeRequire = Object.assign(
 			(requiredName: string) => {
 				if (debug.enabled) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,17 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "noUnusedLocals": true,
-
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "types": [
+      "debug",
+      "fs-extra",
+      "lockfile",
+      "semver",
+      "tar",
+      "url-join",
+      "node-fetch"
+    ]
   },
   "exclude": [
     "samples/plugins",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es2015",
     "moduleResolution": "node",
-
+    "allowSyntheticDefaultImports": true,
     "strict": true,
     "noUnusedLocals": true,
 


### PR DESCRIPTION
By explicitly listing the `types` in `tsconfig.json`, you don't run into issues with `@types/jest` which adds to `NodeRequire`