### PR TITLE
Fix 'variable declared but its value is never read' Typescript errors

### DIFF
--- a/src/PluginManager.ts
+++ b/src/PluginManager.ts
@@ -581,7 +581,7 @@ export class PluginManager {
 			&& semver.satisfies(packageJson.version, version);
 	}
 
-	private async getDownloadedPackage(name: string, version: string): Promise<PackageInfo | undefined> {
+	private async getDownloadedPackage(name: string, _version: string): Promise<PackageInfo | undefined> {
 		const location = this.getPluginLocation(name);
 		if (!(await fs.directoryExists(location))) {
 			return;

--- a/src/PluginVm.ts
+++ b/src/PluginVm.ts
@@ -182,7 +182,7 @@ export class PluginVm {
 				return this.sandboxResolve(pluginContext, moduleDirname, id);
 			},
 			{
-				paths: (request: string) => null // TODO I should I populate this
+				paths: (_request: string) => null // TODO I should I populate this
 			}
 		);
 

--- a/src/fileSystem.ts
+++ b/src/fileSystem.ts
@@ -57,7 +57,7 @@ export function copy(src: string, dest: string, options?: Partial<CopyOptions>):
 		? options.exclude.map((f) => path.join(src, f).toLowerCase())
 		: [];
 
-	const filter = (filterSrc: string, filterDest: string) => {
+	const filter = (filterSrc: string, _filterDest: string) => {
 		filterSrc = filterSrc.toLowerCase();
 
 		if (excludeList.indexOf(filterSrc) >= 0) {


### PR DESCRIPTION
This PR allows for using live-plugin-manager in a typescript project with `noUsedParameters` and/or `noUnusedLocals` set to true. Otherwise we get the following errors at build time:

```
node_modules/live-plugin-manager/src/fileSystem.ts:60:37 - error TS6133: 'filterDest' is declared but its value is never read.

60  const filter = (filterSrc: string, filterDest: string) => {
                                       ~~~~~~~~~~

node_modules/live-plugin-manager/src/PluginManager.ts:584:51 - error TS6133: 'version' is declared but its value is never read.

584  private async getDownloadedPackage(name: string, version: string): Promise<PackageInfo | undefined> {
                                                      ~~~~~~~

node_modules/live-plugin-manager/src/PluginVm.ts:185:13 - error TS6133: 'request' is declared but its value is never read.

185  			paths: (request: string) => null // TODO I should I populate this

```