### PR TITLE
Adds support for installing a single package from a private repo

### DIFF
--- a/src/NpmRegistryClient.ts
+++ b/src/NpmRegistryClient.ts
@@ -141,6 +141,11 @@ function encodeNpmName(name: string) {
 	return name.replace("/", "%2F");
 }
 
+export interface NpmRegistry {
+	url: string,
+	config?: NpmRegistryConfig
+}
+
 export interface NpmRegistryConfig {
 	// actually this is used in the params
 	auth?: NpmRegistryAuthToken | NpmRegistryAuthBasic;

--- a/src/httpUtils.ts
+++ b/src/httpUtils.ts
@@ -20,8 +20,14 @@ export function headersTokenAuth(token: string): Headers {
 }
 
 export function headersBasicAuth(username: string, password: string): Headers {
+	let auth;
+	if(username && password){
+		auth = Buffer.from(username + ":" + password).toString("base64");
+	} else {
+		auth = username;
+	}
 	return {
-		Authorization: "Basic " + Buffer.from(username + ":" + password).toString("base64")
+		Authorization: "Basic " + auth
 	};
 }
 


### PR DESCRIPTION
This PR adds support for installing an NPM package from a private repository while installing all other packages from another repo. This PR also allows passing the encoded token to basic authentication in the event we already have it as base64.

**Scenario to cover:** A package has been pushed to a private repo. While installing, the NPM package needs to be installed from the private repo while the dependencies needs to come from the default public repository.