### PR TITLE
Update locking test

### DIFF
--- a/test/PluginManagerSuite.ts
+++ b/test/PluginManagerSuite.ts
@@ -1118,7 +1118,7 @@ describe("PluginManager:", function() {
 			const installation1 = manager.installFromNpm("moment");
 			const installation2 = manager.installFromPath(pluginSourcePath);
 			try {
-				await Promise.all([ installation1, installation2 ])
+				await Promise.all([ installation1, installation2 ]);
 			} catch (error) {
 				if (/failed to acquire lock/i.test(error as string)) return;
 			}

--- a/test/PluginManagerSuite.ts
+++ b/test/PluginManagerSuite.ts
@@ -1114,21 +1114,15 @@ describe("PluginManager:", function() {
 		});
 
 		it("cannot install multiple package concurrently", async function() {
-			// I expect this to take some time...
-			const installation1 = manager.installFromNpm("moment");
-
-			// so I expect a concurrent installation to fail...
 			const pluginSourcePath = path.join(__dirname, "my-basic-plugin");
+			const installation1 = manager.installFromNpm("moment");
 			const installation2 = manager.installFromPath(pluginSourcePath);
-
 			try {
-				await installation2;
-			} catch (err) {
-				await installation1;
-				return;
+				await Promise.all([ installation1, installation2 ])
+			} catch (error) {
+				if (/failed to acquire lock/i.test(error as string)) return;
 			}
-
-			throw new Error("Expected to fail");
+			throw new Error("Expected to fail acquiring lock");
 		});
 
 		describe("given a lock", function() {


### PR DESCRIPTION
This PR is to hopefully fix some strange errors with the test for locking to prevent multiple parallel installations.

I have not been able to replicate the issue consistently but from what I saw during debugging the issue the test would sometimes not throw an error due to an absence of a lock file.

My hunch is that as there is no way to guarantee promises run in parallel sometimes the installation of the local plugin1 happens all at once in the await and so never conflicting with the "moment" plugin install.

This change makes it so both installs are in theory initiated at once and given that the moment install is more likely to yield in the event loop, more likely to then clash as the local plugin install starts.