### PR TITLE
Add support for files with the .cjs file extension

### DIFF
--- a/src/PluginVm.ts
+++ b/src/PluginVm.ts
@@ -41,7 +41,7 @@ export class PluginVm {
 		moduleInstance = sandbox.module;
 
 		const filePathExtension = path.extname(filePath).toLowerCase();
-		if (filePathExtension === ".js") {
+		if (filePathExtension === ".js" || filePathExtension === ".cjs") {
 			const code = fs.readFileSync(filePath, "utf8");
 			// note: I first put the object (before executing the script) in cache to support circular require
 			this.setCache(pluginContext, filePath, moduleInstance);


### PR DESCRIPTION
Adds support for `.cjs` file extensions. 

For example, when evaluating imports of modules with deep dependency trees, it's possible for `.cjs` files to come up. These should be safe to treat the same as `.js` files since we're operating in a node environment. 

yargs-parser is once example of a module where this occurs;

`/node_modules/yargs-parser/build/index.cjs`

