### PR TITLE
fix: CJS file resolution

### DIFF
--- a/src/PluginVm.ts
+++ b/src/PluginVm.ts
@@ -338,6 +338,10 @@ export class PluginVm {
 		const reqPathKind = checkPath(fullPath);
 
 		if (reqPathKind !== "file") {
+			if (checkPath(fullPath + ".cjs") === "file") {
+				return fullPath + ".cjs";
+			}
+
 			if (checkPath(fullPath + ".js") === "file") {
 				return fullPath + ".js";
 			}
@@ -359,6 +363,11 @@ export class PluginVm {
 	private tryResolveAsDirectory(fullPath: string): string | undefined {
 		if (checkPath(fullPath) !== "directory") {
 			return undefined;
+		}
+
+		const indexCjs = path.join(fullPath, "index.cjs");
+		if (checkPath(indexCjs) === "file") {
+			return indexCjs;
 		}
 
 		const indexJs = path.join(fullPath, "index.js");

--- a/src/PluginVm.ts
+++ b/src/PluginVm.ts
@@ -41,7 +41,7 @@ export class PluginVm {
 		moduleInstance = sandbox.module;
 
 		const filePathExtension = path.extname(filePath).toLowerCase();
-		if (filePathExtension === ".js") {
+		if (filePathExtension === ".js" || filePathExtension === ".cjs") {
 			const code = fs.readFileSync(filePath, "utf8");
 			// note: I first put the object (before executing the script) in cache to support circular require
 			this.setCache(pluginContext, filePath, moduleInstance);


### PR DESCRIPTION
Adds additional checks for `.cjs` files before `.js` files to avoid resolving ESM JS files. 

Packages using ESM sometimes also have entry points for CJS for example: 

<img width="342" alt="image" src="https://github.com/davideicardi/live-plugin-manager/assets/3030010/6b5d10ab-592d-44eb-9149-4a58117ef87a">

This change ensures that CJS is the first extension found if the option exists. When we eventually support ESM, this logic may need to change or be removed.
