### PR TITLE
Adds stub method for process.on

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ plugin_packages
 
 There are some known limitations when installing a package:
 
-- Different plugins cannot depends on different/incompatible modules. If plugin A require module x at version 1 and plugin B require the same module X at version 2 then plugin A and plugin B cannot be installed simultaneously. Version 2 of module X will be used and this can cause problems on your code.
+- Different plugins cannot depend on different/incompatible modules. If plugin A require module x at version 1 and plugin B require the same module X at version 2 then plugin A and plugin B cannot be installed simultaneously. Version 2 of module X will be used and this can cause problems on your code.
+- `process.on` has been stubbed, so plugins that use these events may not work as expected. 
 - No `pre/post-install` scripts are executed (some packages use this scripts to build assets or for platform specific installation, so for this reason some packages are not supported)
 - C/C++ packages (`.node`) are not supported
 - Plugin dependencies can be specified only as NPM dependencies (version number) or github dependencies (owner/repo), url or other kind of dependencies are not supported

--- a/src/PluginVm.ts
+++ b/src/PluginVm.ts
@@ -416,6 +416,7 @@ export class PluginVm {
 			// override env to "unlink" from original process
 			const srcEnv = sandboxTemplate.env || global.process.env;
 			sandbox.process.env = {...srcEnv}; // copy properties
+			(sandbox as any).process.on = (event: string, callback: any) => {};
 		}
 
 		// create global console


### PR DESCRIPTION
https://nodejs.org/api/process.html

When LPM encounters a dependency using `process.on` like so: 

<img width="900" alt="image" src="https://github.com/davideicardi/live-plugin-manager/assets/3030010/b16f0bd9-896e-4e25-bc72-063e31646b0d">

It will throw the following error: `typeerror: process.on is not a function` 

I'm not sure if this is a suitable enough stub method so feel free to let me know if there's a better way to handle it. 😄 